### PR TITLE
Refactor

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,15 +1,22 @@
-pkgbase = github-actions
+pkgbase = github-actions-bin
 	pkgdesc = GitHub Actions self-hosted runner tools.
-	pkgver = 2.161.0
-	pkgrel = 4
-	url = https://help.github.com/en/actions
+	pkgver = 2.165.2
+	pkgrel = 1
+	url = https://github.com/actions/runner
 	install = PKGBUILD
 	arch = x86_64
-	license = custom
+	license = MIT
 	provides = github-actions
 	conflicts = github-actions
-	source = https://githubassets.azureedge.net/runners/2.161.0/actions-runner-linux-x64-2.161.0.tar.gz
-	sha512sums = 711cdb99e6dc34e6cc843ef31befd2db49bfe0463f3da9550663ced9febb362cdf23d4976ce78455edad72d00dd0713114e13c46a5461c454a5a9fe5738b8639
+	source = https://github.com/actions/runner/releases/download/v2.165.2/actions-runner-linux-x64-2.165.2.tar.gz
+	source = github-actions.service
+	source = github-actions.tmpfiles
+	source = github-actions.sysusers
+	sha512sums = f9bfd2756db57cee1632f3c1ea922974ad343cd4ad47753fcf8fd9e6afea2a2f9462715161e33bec29c270b92c4744dcc3564e290cff4dc02ea068fc57707e90
+	sha512sums = abeb32b58cd526bb6abe928d978664de85cab5715d93189919412f889a8a1089a11ec1e8bf21e72e96e8640ca85ecb97daff0c797541317dbe4f6f508c39858d
+	sha512sums = c0a8cc36b353f85d9e05868a20b160c0cd36d983bcb65562dd8c3f2c6321061deec18331156ec75f0b9d7b0009df7412abf2d977e6995cac004c5462282928a8
+	sha512sums = 49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4
 
-pkgname = github-actions
+pkgname = github-actions-bin
+	depends = sudo
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/pkg
+/src
+/*.pkg.tar*
+/*.log

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,51 +1,62 @@
-# Maintainer: Samuel Williams <samuel@oriontransfer.net>
+# Maintainer  : Samuel Williams <samuel@oriontransfer.net>
+# Contributor : Edvinas Valatka <edacval@gmail.com>
 
-pkgname=github-actions
-pkgver=2.161.0
-pkgrel=4
+_pkgname=github-actions
+pkgname=${_pkgname}-bin
+pkgver=2.165.2
+pkgrel=1
 pkgdesc='GitHub Actions self-hosted runner tools.'
 arch=('x86_64')
-url='https://help.github.com/en/actions'
-license=('custom')
+url='https://github.com/actions/runner'
+license=('MIT')
 
 OPTIONS=(!strip !docs libtool emptydirs)
 
 install=PKGBUILD
 
-provides=('github-actions')
-conflicts=('github-actions')
-
+provides=($_pkgname)
+conflicts=($_pkgname)
 source=(
-	https://githubassets.azureedge.net/runners/$pkgver/actions-runner-linux-x64-$pkgver.tar.gz
+       https://github.com/actions/runner/releases/download/v$pkgver/actions-runner-linux-x64-$pkgver.tar.gz
+       github-actions.service
+       github-actions.tmpfiles
+       github-actions.sysusers
 )
 
-sha512sums=('711cdb99e6dc34e6cc843ef31befd2db49bfe0463f3da9550663ced9febb362cdf23d4976ce78455edad72d00dd0713114e13c46a5461c454a5a9fe5738b8639')
+sha512sums=('f9bfd2756db57cee1632f3c1ea922974ad343cd4ad47753fcf8fd9e6afea2a2f9462715161e33bec29c270b92c4744dcc3564e290cff4dc02ea068fc57707e90'
+            'abeb32b58cd526bb6abe928d978664de85cab5715d93189919412f889a8a1089a11ec1e8bf21e72e96e8640ca85ecb97daff0c797541317dbe4f6f508c39858d'
+            'c0a8cc36b353f85d9e05868a20b160c0cd36d983bcb65562dd8c3f2c6321061deec18331156ec75f0b9d7b0009df7412abf2d977e6995cac004c5462282928a8'
+            '49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4')
 
 package() {
-	mkdir -p "$pkgdir/opt/$provides" 
-	cp -r "$srcdir/." "$pkgdir/opt/$provides"
-	
-	install -m755 -d ${pkgdir}/usr/lib/systemd/system || return 1
-	install -m644  $startdir/github-actions.service ${pkgdir}/usr/lib/systemd/system || return 1
+       depends=(sudo)
+       mkdir -p "$pkgdir"/var/lib/$_pkgname
+
+       # Useless on pacman-based distributions
+       rm -f "$srcdir"/bin/installdependencies.sh
+
+       cp -r -t "$pkgdir"/var/lib/$_pkgname "$srcdir"/{bin,externals,*.sh}
+
+       # also see github-actions.tmpfiles
+       chmod 0775 "$pkgdir"/var/lib/$_pkgname
+
+       # make ldd happy
+       chmod +x "$pkgdir"/var/lib/$_pkgname/bin/*.so
+
+       install -Dm644 "$srcdir"/$_pkgname.tmpfiles "${pkgdir}"/usr/lib/tmpfiles.d/$_pkgname.conf
+       install -Dm644 "$srcdir"/$_pkgname.sysusers "${pkgdir}"/usr/lib/sysusers.d/$_pkgname.conf
+       install -Dm644 "$srcdir"/$_pkgname.service  "${pkgdir}"/usr/lib/systemd/system/$_pkgname.service
 }
 
-pre_install() {
-	useradd $provides || true
-}
-
-post_install() {
-	chown -R $provides:$provides /opt/$provides
-}
-
-pre_upgrade() {
-	pre_install
-}
-
-post_upgrade() {
-	post_install
+pre_remove() {
+       if systemctl -q is-enabled $_pkgname.service; then
+              systemctl disable $_pkgname.service
+       fi
 }
 
 post_remove() {
-	userdel -f $provides
-	rm -rf /opt/$provides
+       echo
+       echo "Remove $_pkgname user and this HOME /var/lib/$_pkgname manually, if not needed anymore."
+       echo
 }
+

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ First, clone the repository:
 The build and install it:
 
 	cd github-actions
-	makepkg -fi
+	makepkg -sCcfi
 
 Configure the daemon:
 
-	cd /opt/github-actions
-	./config.sh --token ...
+	sudo -u github-actions -s bash
+	cd /var/lib/github-actions
+	bin/Runner.Listener configure --token YOUR_RUNNER_TOKEN
+	exit
 
 Then start it up:
 
@@ -30,7 +32,7 @@ Then start it up:
 
 You might want to combine this with a container. To create a container (including some suggested packages):
 
-	pacstrap -c github-actions base ruby clang pkg-build vim sudo
+	pacstrap -c github-actions base ruby clang pkg-build vim
 
 Then, import it:
 
@@ -57,8 +59,8 @@ Attach to the container and install the github-actions package:
 	cd /tmp
 	sudo -u nobody git clone https://aur.archlinux.org/github-actions.git
 	cd github-actions
-	sudo -u nobody makepkg -f
-	pacman -U github-actions*.xz
+	sudo -u nobody makepkg -fc
+	pacman -U github-actions*.pkg.tar*
 
 ### Limits
 
@@ -101,9 +103,20 @@ You also may need the container to be running the same Linux kernel and drivers.
 
 You can test this setup using `nvidia-smi` which should show the same output in both the host and container.
 
+## Removing runner
+
+	sudo systemctl stop github-actions
+	sudo systemctl disable github-actions
+	sudo -u github-actions -s bash
+	cd /var/lib/github-actions
+	bin/Runner.Listener remove --token YOUR_RUNNER_TOKEN
+	# prune configuration
+	# rm -rf .config/GitHub* _diag _work .env .path svc.sh
+	exit
+
 ## Contributing
 
-1. Fork it
+1. Fork from https://github.com/ioquatix/github-actions
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/github-actions.service
+++ b/github-actions.service
@@ -3,9 +3,12 @@ Description=GitHub Actions Listener Daemon
 
 [Service]
 User=github-actions
-WorkingDirectory=/opt/github-actions
+WorkingDirectory=~
 Type=exec
-ExecStart=/opt/github-actions/run.sh
+ExecStart=/var/lib/github-actions/externals/node12/bin/node bin/RunnerService.js
+KillMode=process
+KillSignal=SIGINT
+TimeoutStopSec=5min
 
 [Install]
 WantedBy=multi-user.target

--- a/github-actions.sysusers
+++ b/github-actions.sysusers
@@ -1,0 +1,1 @@
+u github-actions - "Github Actions runner" /var/lib/github-actions -

--- a/github-actions.tmpfiles
+++ b/github-actions.tmpfiles
@@ -1,0 +1,2 @@
+# Give write to HOME permision for runner
+z /var/lib/github-actions 0775 root github-actions


### PR DESCRIPTION
Rename package according AUR rules.
Bump version to 2.165.2.
Move runner working dir to /var/lib/github-actions.
Fix license.
Add sudo to dependencies.
Add .gitignore.
Fix source URL.
Silence ldd warnings
Disable service on package removal.
Other minor improvements.